### PR TITLE
Aligns creation of Json values.

### DIFF
--- a/src/main/scala/plda/json/JsonEncoder.scala
+++ b/src/main/scala/plda/json/JsonEncoder.scala
@@ -36,5 +36,4 @@ object JsonEncoder {
   private class JsonEncoderImpl[T](f: T => Json) extends JsonEncoder[T] {
     override def encode(t: T): Json = f(t)
   }
-
 }

--- a/src/test/scala/plda/json/JsonPrettyPrintingTest.scala
+++ b/src/test/scala/plda/json/JsonPrettyPrintingTest.scala
@@ -21,11 +21,9 @@ class JsonPrettyPrintingTest extends FunSpec {
     describe("behavior of flat object stringification") {
       it("simple flat object") {
         val expected = """{"answer_to_life_universe_and_everything_else":42,"question":"What do you get if you multiply six by nine?"}"""
-        val obj = JsonObject(
-          Map(
-            "answer_to_life_universe_and_everything_else" -> JsonNumber(42),
-            "question" -> JsonString("What do you get if you multiply six by nine?")
-          )
+        val obj = JsonValue (
+            "answer_to_life_universe_and_everything_else" -> JsonValue(42),
+            "question" -> JsonValue("What do you get if you multiply six by nine?")
         )
         val result = noSpaces(obj)
         println(result)
@@ -36,9 +34,9 @@ class JsonPrettyPrintingTest extends FunSpec {
         val expected = """{"otheranswers":[54,33],"answer_to_life_universe_and_everything_else":42,"question":"What do you get if you multiply six by nine?"}"""
         val obj = JsonObject(
           Map(
-            "otheranswers" -> JsonArray(List(JsonNumber(54), JsonNumber(33))),
-            "answer_to_life_universe_and_everything_else" -> JsonNumber(42),
-            "question" -> JsonString("What do you get if you multiply six by nine?"),
+            "otheranswers" -> JsonValue(JsonValue(54), JsonValue(33)),
+            "answer_to_life_universe_and_everything_else" -> JsonValue(42),
+            "question" -> JsonValue("What do you get if you multiply six by nine?"),
           )
         )
         val result = noSpaces(obj)
@@ -50,26 +48,18 @@ class JsonPrettyPrintingTest extends FunSpec {
     describe("nested objects") {
       it("stringify nested object") {
         val expected = """{"question":{"part1":"The answer to life?","part2":"The Universe?","part3":"And Everything else?"},"answer":42}"""
-        val obj = JsonObject(
-          Map[String, Json](
-            "question" -> JsonObject {
-              Map(
-                "part1" -> JsonString("The answer to life?"),
-                "part2" -> JsonString("The Universe?"),
-                "part3" -> JsonString("And Everything else?"),
-              )
-            },
-            "answer" -> JsonNumber(42),
-          )
+        val obj = JsonValue(
+            "question" -> JsonValue (
+                "part1" -> JsonValue("The answer to life?"),
+                "part2" -> JsonValue("The Universe?"),
+                "part3" -> JsonValue("And Everything else?"),
+            ),
+            "answer" -> JsonValue(42),
         )
         val result = noSpaces(obj)
         println(result)
         assert(expected == result)
       }
     }
-
-
   }
-
-
 }

--- a/src/test/scala/plda/json/JsonSyntaxTest.scala
+++ b/src/test/scala/plda/json/JsonSyntaxTest.scala
@@ -34,14 +34,10 @@ class JsonSyntaxTest extends FunSpec {
 
     describe("with implicit Encoder in scope") {
 
-      implicit val PLDALabEncoder: JsonEncoder[PLDALab] = new JsonEncoder[PLDALab] {
-        override def encode(t: PLDALab): Json = JsonObject(
-          Map(
-            "labNumber" -> JsonNumber(t.labNumber),
-            "topic" -> JsonString("topic")
-          )
-        )
-      }
+      implicit val PLDALabEncoder: JsonEncoder[PLDALab] = (t: PLDALab) => JsonValue (
+        "labNumber" -> JsonValue(t.labNumber),
+        "topic" -> JsonValue("topic")
+      )
 
       it("should compile by finding the encoder in scope") {
         assertCompiles(
@@ -114,14 +110,10 @@ class JsonSyntaxTest extends FunSpec {
   }
 
   describe("encoder + pretty printing syntax") {
-    implicit val PLDALabEncoder: JsonEncoder[PLDALab] = new JsonEncoder[PLDALab] {
-      override def encode(t: PLDALab): Json = JsonObject(
-        Map(
-          "labNumber" -> JsonNumber(t.labNumber),
-          "topic" -> JsonString("topic")
-        )
-      )
-    }
+    implicit val PLDALabEncoder: JsonEncoder[PLDALab] = (t: PLDALab) => JsonValue (
+        "labNumber" -> JsonValue(t.labNumber),
+        "topic" -> JsonValue("topic")
+    )
     it("should allow transforming to json then prettyPrinting") {
       assertCompiles(
         """


### PR DESCRIPTION
- Replaces the direct calls to the case class constructors with the utility methods provided in `JsonValue`.
- Simplifies the syntax for the `JsonEncoder` in the syntax tests, since it's only a lambda (the new class syntax adds unnecessary verbosity).